### PR TITLE
Add fix for complete and flush tables

### DIFF
--- a/dba/migrations/000013_complete_fix.down.sql
+++ b/dba/migrations/000013_complete_fix.down.sql
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2022 Coinbase Global, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+DROP FUNCTION IF EXISTS complete_transaction cascade;
+CREATE OR REPLACE FUNCTION complete_transaction(
+    arg_transaction_id UUID,
+    arg_request_id UUID
+) RETURNS transaction_result
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    temp_transaction      transaction;
+    temp_hold             hold;
+    sender_account        account;
+    receiver_account      account;
+    most_recent_sender_balance   account_balance;
+    most_recent_receiver_balance account_balance;
+    temp_balance_amount          NUMERIC;
+    sender_hold_amount           NUMERIC;
+    sender_entry_id              UUID;
+    receiver_entry_id            UUID;
+    sender_balance_id            UUID;
+    receiver_balance_id          UUID;
+    result                transaction_result;
+BEGIN
+    SELECT *
+    FROM transaction
+    WHERE id = arg_transaction_id
+      AND EXISTS(
+            SELECT * FROM finalized_transaction WHERE transaction_id = arg_transaction_id)
+    INTO temp_transaction;
+    IF FOUND THEN
+        result.sender_balance_id = (SELECT id
+                                    FROM account_balance
+                                    WHERE request_id = arg_request_id
+                                      AND account_id = temp_transaction.sender_id);
+        result.receiver_balance_id = (SELECT id
+                                      FROM account_balance
+                                      WHERE request_id = arg_request_id
+                                        AND account_id = temp_transaction.receiver_id);
+        return result;
+    end if;
+
+    --Locking
+    LOCK TABLE account IN ROW EXCLUSIVE MODE;
+    SELECT * FROM account WHERE id = temp_transaction.sender_id into sender_account FOR UPDATE;
+    SELECT * FROM account WHERE id = temp_transaction.receiver_id into receiver_account FOR UPDATE;
+
+    SELECT * FROM transaction WHERE id = arg_transaction_id INTO temp_transaction;
+
+    SELECT *
+    FROM get_unreleased_hold(temp_transaction.id, temp_transaction.sender_id)
+    INTO temp_hold;
+
+    IF FOUND THEN
+      --Release the hold
+      INSERT INTO released_hold (hold_id, request_id) VALUES (temp_hold.id, arg_request_id);
+      --Insert Sender Balance
+      temp_balance_amount = most_recent_sender_balance.balance - temp_hold.amount;
+      sender_hold_amount = most_recent_sender_balance.hold - temp_hold.amount;
+      INSERT INTO account_balance(account_id, request_id, balance, hold, available, count)
+      VALUES (temp_transaction.sender_id, arg_request_id, temp_balance_amount, sender_hold_amount,
+              temp_balance_amount - sender_hold_amount, most_recent_sender_balance.count + 1)
+      RETURNING id INTO sender_balance_id;
+      result.sender_balance_id = sender_balance_id;
+    end if;
+
+    --Finalize Transaction
+    INSERT INTO finalized_transaction (transaction_id, completed_at, request_id)
+    VALUES (arg_transaction_id, now(), arg_request_id);
+
+    UPDATE account SET user_id = sender_account.user_id WHERE id = sender_account.id;
+    UPDATE account SET user_id = receiver_account.user_id WHERE id = receiver_account.id;
+
+    return result;
+END
+$$;

--- a/dba/migrations/000013_complete_fix.up.sql
+++ b/dba/migrations/000013_complete_fix.up.sql
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2022 Coinbase Global, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+DROP FUNCTION IF EXISTS complete_transaction cascade;
+CREATE OR REPLACE FUNCTION complete_transaction(
+    arg_transaction_id UUID,
+    arg_request_id UUID
+) RETURNS transaction_result
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    temp_transaction      transaction;
+    temp_hold             hold;
+    sender_account        account;
+    receiver_account      account;
+    most_recent_sender_balance   account_balance;
+    most_recent_receiver_balance account_balance;
+    temp_balance_amount          NUMERIC;
+    sender_hold_amount           NUMERIC;
+    sender_entry_id              UUID;
+    receiver_entry_id            UUID;
+    sender_balance_id            UUID;
+    receiver_balance_id          UUID;
+    result                transaction_result;
+BEGIN
+    SELECT *
+    FROM transaction
+    WHERE id = arg_transaction_id
+      AND EXISTS(
+            SELECT * FROM finalized_transaction WHERE transaction_id = arg_transaction_id)
+    INTO temp_transaction;
+    IF FOUND THEN
+        result.sender_balance_id = (SELECT id
+                                    FROM account_balance
+                                    WHERE request_id = arg_request_id
+                                      AND account_id = temp_transaction.sender_id);
+        result.receiver_balance_id = (SELECT id
+                                      FROM account_balance
+                                      WHERE request_id = arg_request_id
+                                        AND account_id = temp_transaction.receiver_id);
+        return result;
+    end if;
+
+    --Locking
+    LOCK TABLE account IN ROW EXCLUSIVE MODE;
+    SELECT * FROM account WHERE id = temp_transaction.sender_id into sender_account FOR UPDATE;
+    SELECT * FROM account WHERE id = temp_transaction.receiver_id into receiver_account FOR UPDATE;
+
+    SELECT * FROM transaction WHERE id = arg_transaction_id INTO temp_transaction;
+
+    SELECT *
+    FROM get_unreleased_hold(temp_transaction.id, temp_transaction.sender_id)
+    INTO temp_hold;
+
+    IF FOUND THEN
+      --Release the hold
+      INSERT INTO released_hold (hold_id, request_id) VALUES (temp_hold.id, arg_request_id);
+      --Get most recent sender balance
+      SELECT * FROM get_latest_balance(temp_transaction.sender_id) INTO most_recent_sender_balance;
+      --Insert Sender Balance
+      sender_hold_amount = most_recent_sender_balance.hold - temp_hold.amount;
+      INSERT INTO account_balance(account_id, request_id, balance, hold, available, count)
+      VALUES (temp_transaction.sender_id, arg_request_id,most_recent_sender_balance.balance, sender_hold_amount,
+              most_recent_sender_balance.balance - sender_hold_amount, most_recent_sender_balance.count + 1)
+      RETURNING id INTO sender_balance_id;
+      result.sender_balance_id = sender_balance_id;
+    end if;
+
+    --Finalize Transaction
+    INSERT INTO finalized_transaction (transaction_id, completed_at, request_id)
+    VALUES (arg_transaction_id, now(), arg_request_id);
+
+    UPDATE account SET user_id = sender_account.user_id WHERE id = sender_account.id;
+    UPDATE account SET user_id = receiver_account.user_id WHERE id = receiver_account.id;
+
+    return result;
+END
+$$;

--- a/dba/migrations/000014_reset_tables.down.sql
+++ b/dba/migrations/000014_reset_tables.down.sql
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2022 Coinbase Global, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+DELETE
+FROM released_hold;
+DELETE
+FROM hold;
+DELETE
+FROM entry;
+DELETE
+FROM finalized_transaction;
+DELETE
+FROM transaction;
+DELETE
+FROM account_balance;
+DELETE
+FROM account;
+
+/*
+ * Neoworks Fee Accounts
+*/
+INSERT INTO account(id, portfolio_id, user_id, currency, created_at)
+VALUES ('B72D0E55-F53A-4DB0-897E-2CE4A73CB94B', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        '116BDE43-7733-43A1-A85A-FC8627E6DA8E', 'USD', now());
+
+/*
+ * Coinbase Fee Accounts
+*/
+INSERT INTO account(id, portfolio_id, user_id, currency, created_at)
+VALUES ('C4D0E14E-1B2B-4023-AFA6-8891AD1960C9', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        '433C0C15-0A44-49C4-A207-4501BB11F48C', 'USD', now());
+
+/*
+ * Demo Accounts
+ */
+
+INSERT INTO account (id, portfolio_id, user_id, currency, created_at)
+VALUES ('0adbb104-fc18-46ca-a4eb-beee7775eb69', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'USD', now());
+
+INSERT INTO account_balance(account_id, balance, hold, available, created_at, request_id, count)
+VALUES ('0adbb104-fc18-46ca-a4eb-beee7775eb69', 10000, 0, 10000, now(), null, 1);
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'ETH');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'SOL');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'BTC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'ADA');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'MATIC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'ATOM');
+
+/*
+ * Demo1 Accounts
+ */
+
+INSERT INTO account (id, portfolio_id, user_id, currency, created_at)
+VALUES ('8e2ee8eb-2057-4996-8d32-9eef6a6ab824', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'USD', now());
+
+INSERT INTO account_balance(account_id, balance, hold, available, created_at, request_id, count)
+VALUES ('8e2ee8eb-2057-4996-8d32-9eef6a6ab824', 10000, 0, 10000, now(), null, 0);
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'ETH');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'SOL');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'BTC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'ADA');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'MATIC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'ATOM');

--- a/dba/migrations/000014_reset_tables.up.sql
+++ b/dba/migrations/000014_reset_tables.up.sql
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2022 Coinbase Global, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+DELETE
+FROM released_hold;
+DELETE
+FROM hold;
+DELETE
+FROM entry;
+DELETE
+FROM finalized_transaction;
+DELETE
+FROM transaction;
+DELETE
+FROM account_balance;
+DELETE
+FROM account;
+
+/*
+ * Neoworks Fee Accounts
+*/
+INSERT INTO account(id, portfolio_id, user_id, currency, created_at)
+VALUES ('B72D0E55-F53A-4DB0-897E-2CE4A73CB94B', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        '116BDE43-7733-43A1-A85A-FC8627E6DA8E', 'USD', now());
+
+/*
+ * Coinbase Fee Accounts
+*/
+INSERT INTO account(id, portfolio_id, user_id, currency, created_at)
+VALUES ('C4D0E14E-1B2B-4023-AFA6-8891AD1960C9', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        '433C0C15-0A44-49C4-A207-4501BB11F48C', 'USD', now());
+
+/*
+ * Demo Accounts
+ */
+
+INSERT INTO account (id, portfolio_id, user_id, currency, created_at)
+VALUES ('0adbb104-fc18-46ca-a4eb-beee7775eb69', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'USD', now());
+
+INSERT INTO account_balance(account_id, balance, hold, available, created_at, request_id, count)
+VALUES ('0adbb104-fc18-46ca-a4eb-beee7775eb69', 10000, 0, 10000, now(), null, 1);
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'ETH');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'SOL');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'BTC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'ADA');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'MATIC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', 'c5af3271-7185-4a52-9d0c-1c4b418317d8', 'ATOM');
+
+/*
+ * Demo1 Accounts
+ */
+
+INSERT INTO account (id, portfolio_id, user_id, currency, created_at)
+VALUES ('8e2ee8eb-2057-4996-8d32-9eef6a6ab824', 'D263E7E3-24D7-4C04-8D67-EA3A0BE7907E',
+        '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'USD', now());
+
+INSERT INTO account_balance(account_id, balance, hold, available, created_at, request_id, count)
+VALUES ('8e2ee8eb-2057-4996-8d32-9eef6a6ab824', 10000, 0, 10000, now(), null, 0);
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'ETH');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'SOL');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'BTC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'ADA');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'MATIC');
+
+SELECT * FROM initialize_account('D263E7E3-24D7-4C04-8D67-EA3A0BE7907E', '36ae23e7-d79e-4901-89d5-3fa87cca1abf', 'ATOM');


### PR DESCRIPTION
The complete function was trying to subtract balance from the sender when we're flushing the final hold amount. This fixes that bug and then adds a migration to flush all the tables and redeploy the initial accounts.